### PR TITLE
Support for async-http-client 2.0.3 with Netty 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ scala:
   - 2.11.7
   - 2.10.6
 
+jdk:
+  - oraclejdk8
+
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -jvm-opts .travis.jvmopts clean coverage test
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,7 @@ testOptions in Test += Tests.Argument("-oDF")
 useGpg := true
 releaseCrossBuild := true
 
-libraryDependencies += "com.ning" % "async-http-client" % "1.9.36"
-libraryDependencies += "io.netty" % "netty" % "3.10.5.Final"
+libraryDependencies += "org.asynchttpclient" % "async-http-client" % "2.0.3"
 libraryDependencies += "io.spray" %%  "spray-json" % "1.3.2"
 libraryDependencies += "com.github.tomakehurst" % "wiremock" % "1.57" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"

--- a/src/main/scala/com/paulgoldbaum/influxdbclient/HttpConfig.scala
+++ b/src/main/scala/com/paulgoldbaum/influxdbclient/HttpConfig.scala
@@ -1,9 +1,9 @@
 package com.paulgoldbaum.influxdbclient
 
-import com.ning.http.client.AsyncHttpClientConfig
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 
 class HttpConfig {
-  private var builder = new AsyncHttpClientConfig.Builder
+  private var builder = new DefaultAsyncHttpClientConfig.Builder
 
   def setConnectTimeout(timeout: Int) = {
     builder = builder.setConnectTimeout(timeout)

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/CustomTestSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/CustomTestSuite.scala
@@ -1,18 +1,22 @@
 package com.paulgoldbaum.influxdbclient
 
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import scala.concurrent.duration._
-import scala.concurrent.{Awaitable, Await}
+import scala.concurrent.{Await, Awaitable}
 
-class CustomTestSuite extends FunSuite {
+class CustomTestSuite extends FunSuite with BeforeAndAfterAll {
 
   val waitDuration = 2.seconds
   val databaseUsername = "influx_user"
   val databasePassword = "influx_password"
 
+  val influxdb = InfluxDB.connect("localhost", 8086, databaseUsername, databasePassword, false)
+
   def await[T](f: Awaitable[T], duration: Duration = waitDuration) = Await.result(f, duration)
 
-  val influxdb = InfluxDB.connect("localhost", 8086, databaseUsername, databasePassword, false)
+  override def afterAll = {
+    influxdb.close()
+  }
 
 }

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
@@ -4,7 +4,7 @@ import com.paulgoldbaum.influxdbclient.Mocks.{ExceptionThrowingHttpClient, Error
 import com.paulgoldbaum.influxdbclient.Parameter.{Consistency, Precision}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter}
 
-class DatabaseSuite extends CustomTestSuite with BeforeAndAfter with BeforeAndAfterAll {
+class DatabaseSuite extends CustomTestSuite with BeforeAndAfter {
 
   val database = influxdb.selectDatabase("_test_database_db")
 
@@ -17,8 +17,10 @@ class DatabaseSuite extends CustomTestSuite with BeforeAndAfter with BeforeAndAf
     await(database.create())
   }
 
-  override def afterAll() =
+  override def afterAll = {
     await(database.drop())
+    super.afterAll
+  }
 
   test("Writing to a non-existent database throws a DatabaseNotFoundException") {
     val database = influxdb.selectDatabase("_test_database_db_2")

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/InfluxDBSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/InfluxDBSuite.scala
@@ -12,6 +12,7 @@ class InfluxDBSuite extends CustomTestSuite {
     assert(httpClient.port == 8086)
     assert(httpClient.username == null)
     assert(httpClient.password == null)
+    influxdb.close()
   }
 
   test("Overridden parameters are returned in client") {
@@ -27,6 +28,7 @@ class InfluxDBSuite extends CustomTestSuite {
     assert(httpClient.port == 1234)
     assert(httpClient.username == "user")
     assert(httpClient.password == "password")
+    influxdb.close()
   }
 
   test("Returns correct database") {
@@ -41,6 +43,7 @@ class InfluxDBSuite extends CustomTestSuite {
 
   test("Server can be pinged") {
     await(influxdb.ping())
+
   }
 
   test("If an error happens during a ping a PingException is thrown") {
@@ -50,6 +53,8 @@ class InfluxDBSuite extends CustomTestSuite {
       fail("Exception not thrown")
     } catch {
       case e: PingException => // expected
+    } finally {
+      client.close()
     }
   }
 
@@ -60,6 +65,8 @@ class InfluxDBSuite extends CustomTestSuite {
       fail("Exception not thrown")
     } catch {
       case e: QueryException => // expected
+    } finally {
+      client.close()
     }
   }
 

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/UserManagementSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/UserManagementSuite.scala
@@ -1,5 +1,7 @@
 package com.paulgoldbaum.influxdbclient
 
+import org.scalatest.BeforeAndAfterAll
+
 class UserManagementSuite extends CustomTestSuite {
 
   val username = "_test_username"


### PR DESCRIPTION
Sorry for the delay! As I said in #16, here's a patch to support async-http-client 2.0 (now released) and Netty 4.

Almost no changes were needed, except in one particular case: I didn't manage to trigger a `readTimeout` no matter what I tried. I think in their refactor of the library they changed how this timeout is triggered, and now just mocking the call isn't enough, but I'm not so sure.

I also started closing the connections after the tests, since Netty was complaining of having too many timers instantiated.
