### PR TITLE
Precision and Consistency extend Serializable

### DIFF
--- a/src/main/scala/com/paulgoldbaum/influxdbclient/Parameter.scala
+++ b/src/main/scala/com/paulgoldbaum/influxdbclient/Parameter.scala
@@ -3,7 +3,7 @@ package com.paulgoldbaum.influxdbclient
 object Parameter {
 
   object Precision {
-    sealed abstract class Precision(str: String) {
+    sealed abstract class Precision(str: String) extends Serializable {
       override def toString = str
     }
 
@@ -16,7 +16,7 @@ object Parameter {
   }
 
   object Consistency {
-    sealed abstract class Consistency(str: String) {
+    sealed abstract class Consistency(str: String) extends Serializable {
       override def toString = str
     }
 


### PR DESCRIPTION
In order to be able to use the client with Apache Flink `Precision` and `Consistency` have to extend Serializable.