### PR TITLE
Introduce new type class called `ToPoint`

### DIFF
--- a/src/main/scala/com/paulgoldbaum/influxdbclient/Database.scala
+++ b/src/main/scala/com/paulgoldbaum/influxdbclient/Database.scala
@@ -2,6 +2,7 @@ package com.paulgoldbaum.influxdbclient
 
 import com.paulgoldbaum.influxdbclient.Parameter.Consistency.Consistency
 import com.paulgoldbaum.influxdbclient.Parameter.Precision.Precision
+import com.paulgoldbaum.influxdbclient.implicits.ToPointSyntax
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -12,12 +13,12 @@ class Database protected[influxdbclient]
   with RetentionPolicyManagement
   with DatabaseManagement
 {
-  def write(point: Point,
+  def write[A](point: A,
             precision: Precision = null,
             consistency: Consistency = null,
-            retentionPolicy: String = null): Future[Boolean] =
+            retentionPolicy: String = null)(implicit toPoint: ToPoint[A]): Future[Boolean] =
   {
-    executeWrite(point.serialize(), precision, consistency, retentionPolicy)
+    executeWrite(point.toPoint.serialize(), precision, consistency, retentionPolicy)
   }
 
   def bulkWrite(points: Seq[Point],

--- a/src/main/scala/com/paulgoldbaum/influxdbclient/ToPoint.scala
+++ b/src/main/scala/com/paulgoldbaum/influxdbclient/ToPoint.scala
@@ -1,0 +1,17 @@
+package com.paulgoldbaum.influxdbclient
+
+trait ToPoint[-A] {
+
+  def convert(value: A): Point
+
+}
+
+object ToPoint {
+
+  implicit object PointToPoint extends ToPoint[Point]{
+
+    override def convert(value: Point): Point = value
+
+  }
+
+}

--- a/src/main/scala/com/paulgoldbaum/influxdbclient/implicits/package.scala
+++ b/src/main/scala/com/paulgoldbaum/influxdbclient/implicits/package.scala
@@ -1,0 +1,14 @@
+package com.paulgoldbaum.influxdbclient
+
+package object implicits {
+
+  implicit class ToPointSyntax[A](val value: A) extends AnyVal {
+
+    def toPoint(implicit toPoint: ToPoint[A]): Point = toPoint.convert(value)
+
+  }
+
+  implicit def anyToPoint[A](value: A)(implicit toPoint: ToPoint[A]): Point =
+    toPoint.convert(value)
+
+}

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
@@ -59,6 +59,18 @@ class DatabaseSuite extends CustomTestSuite with BeforeAndAfter {
     assert(result.series.length == 1)
   }
 
+  test("A point can be written using ToPoint type class") {
+    case class Metric(value: Int, tag: String)
+    object Metric {
+      implicit val metricToPoint: ToPoint[Metric] = m =>
+        Point("test_measurement").addField("value", m.value).addTag("tag_key", m.tag)
+    }
+
+    await(database.write(Metric(123, "tag_value")))
+    val result = await(database.query("SELECT * FROM test_measurement WHERE tag_key='tag_value'"))
+    assert(result.series.length == 1)
+  }
+
   test("A point can be written and read with a precision parameter") {
     val time = 1444760421270l
     await(

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/DatabaseSuite.scala
@@ -60,12 +60,6 @@ class DatabaseSuite extends CustomTestSuite with BeforeAndAfter {
   }
 
   test("A point can be written using ToPoint type class") {
-    case class Metric(value: Int, tag: String)
-    object Metric {
-      implicit val metricToPoint: ToPoint[Metric] = m =>
-        Point("test_measurement").addField("value", m.value).addTag("tag_key", m.tag)
-    }
-
     await(database.write(Metric(123, "tag_value")))
     val result = await(database.query("SELECT * FROM test_measurement WHERE tag_key='tag_value'"))
     assert(result.series.length == 1)

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/Metric.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/Metric.scala
@@ -1,0 +1,11 @@
+package com.paulgoldbaum.influxdbclient
+
+/**
+ * Class used for testing purposes.
+ */
+case class Metric(value: Int, tag: String)
+
+object Metric {
+  implicit val metricToPoint: ToPoint[Metric] = m =>
+    Point("test_measurement").addField("value", m.value).addTag("tag_key", m.tag)
+}

--- a/src/test/scala/com/paulgoldbaum/influxdbclient/Metric.scala
+++ b/src/test/scala/com/paulgoldbaum/influxdbclient/Metric.scala
@@ -6,6 +6,11 @@ package com.paulgoldbaum.influxdbclient
 case class Metric(value: Int, tag: String)
 
 object Metric {
-  implicit val metricToPoint: ToPoint[Metric] = m =>
-    Point("test_measurement").addField("value", m.value).addTag("tag_key", m.tag)
+  implicit val metricToPoint: ToPoint[Metric] = new ToPoint[Metric] {
+    override def convert(m: Metric): Point =
+      Point("test_measurement")
+        .addField("value", m.value)
+        .addTag("tag_key", m.tag)
+  }
+
 }


### PR DESCRIPTION
Main reason of adding this feature is to allow submitting
custom domain models to InfluxDB without constructing `Point` instance
every time.

This PR is only a Proof of concept and is a subject to discuss. If this feature will be accepted I will add proper documentation.